### PR TITLE
Improved README with some HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 ![Contributors](https://img.shields.io/github/contributors/Ghost-chu/QuickShop-Reremake)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FGhost-chu%2FQuickShop-Reremake.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FGhost-chu%2FQuickShop-Reremake?ref=badge_shield)
 ---
-[![JoinDiscord](https://img.shields.io/badge/join-discord-blue.svg) ![Chatting](https://img.shields.io/discord/471882534712639488)](https://discord.gg/bfefw2E)
-
 ![Java](https://img.shields.io/badge/java-version%208%2B%20(currently%20is%208--17)-orange)
 ![MC](https://img.shields.io/badge/minecraft-java%20edition%201.13.2%2B-blueviolet)
 ![Ver](https://img.shields.io/spiget/version/62575?label=version)
@@ -17,11 +15,11 @@
 QuickShop is a shop plugin that allows players to easily sell/buy any items from a chest without any commands.
 In fact, none of the commands that QuickShop provides are ever needed by a player.
 QuickShop-Reremake is a fork of QuickShop NotLikeMe with more features, bug fixes and other improvements.  
-QuickShop-Reremake is made by PotatoCraft Studio from the https://github.com/KaiKikuchi/QuickShop upstream repository.
+QuickShop-Reremake is made by PotatoCraft Studio from [KaiKikuchi's QuickShop upstream repository](https://github.com/KaiKikuchi/QuickShop).
 
 ## Support
-
-Open a new issue here: https://github.com/Ghost-chu/QuickShop-Reremake/issues
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Discord:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Open an issue:</p>
+<a href="https://discord.gg/bfefw2E"/> <img src="https://upload.wikimedia.org/wikipedia/fr/4/4f/Discord_Logo_sans_texte.svg" width="100" height="100" /> <a href="https://github.com/Ghost-chu/QuickShop-Reremake/issues"><img src="https://img.icons8.com/material-outlined/72/github.png" width="100" height="100" />
 
 ## Features
 
@@ -42,21 +40,13 @@ Open a new issue here: https://github.com/Ghost-chu/QuickShop-Reremake/issues
 - Powerful API [Reremake]
 - Optimized performance [Reremake]
 
-
-## Builds
-
-Stable: [CodeMC.io Jenkins](https://ci.codemc.io/job/Ghost-chu/job/QuickShop-Reremake/)  
-Snapshot: [CodeMC.io Jenkins](https://ci.codemc.io/job/Ghost-chu/job/QuickShop-Reremake-SNAPSHOT/)
-
-## Links
-- [SpigotMC](https://www.spigotmc.org/resources/62575/)  
-- [BukkitDev](https://dev.bukkit.org/projects/quickshop-reremake)  
-- [Minecraft Chinese Forum (MCBBS)](http://www.mcbbs.net/thread-809496-1-1.html)
-- [Relatev](http://www.relatev.com/forum.php?mod=viewthread&tid=2251)
-- [Jenkins](https://ci.codemc.io/job/Ghost-chu/job/QuickShop-Reremake/)
+## Downloads
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Spigot:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;BukkitDev:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MCBBS:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jenkins:</p>
+<a href="https://www.spigotmc.org/resources/62575/"/> <img src="https://static.spigotmc.org/img/spigot.png" width="100" height="100" /> <a href="https://dev.bukkit.org/projects/quickshop-reremake"><img src="https://lh3.googleusercontent.com/gqndKtICs0CgcMEsQlt4isTW6k3SHoHh4mcu02v0_NSW-aYT6_xNbizKMTw0HPj4peDQZ731euU7l7HT6BcwaF_vYFIl42O85HY=s400" width="100" height="100" /> <a href="http://www.mcbbs.net/thread-809496-1-1.html"><img src="https://www.mcbbs.net/template/mcbbs/image/logo_sc.png" width="100" height="100" /> <a href="https://ci.codemc.io/job/Ghost-chu/job/QuickShop-Reremake-SNAPSHOT/"><img src="https://upload.wikimedia.org/wikipedia/commons/e/e9/Jenkins_logo.svg" width="100" height="100" />
+    
 
 ## Contribute
-If you're a developer, you can contribute to the QuickShop code! Just make a fork and install the Lombok plugin, then make a pull request when you're done! Please try to follow [Google Java Style](https://google.github.io/styleguide/javaguide.html). Also do not increase the plugin version number. Thank you very much!
+[]()If you're a developer, you can contribute to the QuickShop code! Just make a fork and install the Lombok plugin, then make a pull request when you're done! Please try to follow [Google Java Style](https://google.github.io/styleguide/javaguide.html). Also do not increase the plugin version number. Thank you very much!
 
 ## Maven
 ```XML
@@ -74,9 +64,6 @@ If you're a developer, you can contribute to the QuickShop code! Just make a for
 ```
 
 ## Bstats
-
-![Bstats-Servers](https://img.shields.io/bstats/servers/3320)
-![Bstats-Players](https://img.shields.io/bstats/players/3320)
 
 [![BigImage](https://bstats.org/signatures/bukkit/QuickShop-Reremake.svg)](https://bstats.org/plugin/bukkit/QuickShop-Reremake/3320)
 


### PR DESCRIPTION
Changes:

-Made KaiKikuchi's QuickShop upstream repository link look better
-Made Support category look a lot better with HTML
-Made Downloads category look a lot better using HTML (I had to remove "Relatev" because I couldn't find a logo that worked...and the resource itself was very outdated...so I guess it wasn't used/needed anymore)
-Removed Jenkins link for stable builds as they are provided via the other sites
-Removed 2 small Bstats badges because this info is already in the big graph

If you want to see exactly how it looks before merging: [Link](https://github.com/Chris6ix/QuickShop-Reremake/blob/Chris6ix-Improved-README/README.md)
Tell me how you guys like it :)